### PR TITLE
CREACIÓN AUTOMÓVILES COMPLETO

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/web/AutomovilController.java
+++ b/src/main/java/org/springframework/samples/petclinic/web/AutomovilController.java
@@ -82,5 +82,23 @@ public class AutomovilController {
 			return listadoAutomoviles(modelMap);
 		}
 	}
+	
+	@GetMapping("/new")
+	public String editNewAutomovil(ModelMap modelMap) {
+		modelMap.addAttribute("automovil",new Automovil());
+		modelMap.addAttribute("trabajadores", trabService.findAll());
+		return "automoviles/updateAutomovilForm";
+	} 
+	
+	@PostMapping("/new")
+	public String saveNewAutomovil(@Valid Automovil automovil, BindingResult binding, ModelMap modelMap) {
+		if(binding.hasErrors()) {			
+			return "automoviles/updateAutomovilForm";
+		}else {
+			autoService.save(automovil);
+			modelMap.addAttribute("message","Automóvil creado correctamente");
+			return listadoAutomoviles(modelMap);
+		}
+	}
 
 }

--- a/src/main/webapp/WEB-INF/jsp/automoviles/listadoAutomoviles.jsp
+++ b/src/main/webapp/WEB-INF/jsp/automoviles/listadoAutomoviles.jsp
@@ -62,4 +62,7 @@
         </c:forEach>
         </tbody>
     </table>
+    <p>
+    	<a href="/automoviles/new" class="btn  btn-success"><span class="glyphicon glyphicon-plus" aria-hidden="true"></span>Añadir automóvil</a>
+    </p>
 </petclinic:layout>

--- a/src/main/webapp/WEB-INF/jsp/automoviles/updateAutomovilForm.jsp
+++ b/src/main/webapp/WEB-INF/jsp/automoviles/updateAutomovilForm.jsp
@@ -23,7 +23,14 @@
     	        </c:forEach>
 		</select>
 
-             <input type="hidden" name="id" id="id" value="${automovil.id}"/>                    
-             <button class="btn btn-default" type="submit">Actualizar automóvil</button>
+             <input type="hidden" name="id" id="id" value="${automovil.id}"/>
+             <c:choose>
+                    <c:when test="${automovil['new']}">
+                        <button class="btn btn-default" type="submit">Añadir automóvil</button>
+                    </c:when>
+                    <c:otherwise>
+                        <button class="btn btn-default" type="submit">Actualizar automóvil</button>
+                    </c:otherwise>
+                </c:choose>
     </form:form>
 </petclinic:layout>


### PR DESCRIPTION
A partir de la historia de usuario H10 - Dar de alta un vehículo, se han añadido dos métodos en el controlador de automóviles: uno para mostrar el formulario de creación de automóviles y otro para guardar el automóvil nuevo en la BD. Aparte, se ha añadido un botón al final del listado de automóviles que muestre el formulario de creación de automóviles.